### PR TITLE
Add composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,7 @@
+{
+	"name"       : "pressjitsu/wp-transients-cleaner",
+	"type"       : "wordpress-plugin",
+	"require"    : {
+		"composer/installers": "~1.0"
+	}
+}


### PR DESCRIPTION
With this change, WordPress and WP Transients Cleaner can be installed using Composer with the following example composer.json file:

``` json
{
  "repositories":[
    { "type": "vcs", "url": "https://github.com/pressjitsu/wp-transients-cleaner" }
  ],
  "require": {
    "johnpbloch/wordpress": "*",
    "pressjitsu/wp-transients-cleaner": "dev-master"
  }
}
```

Simply create this file, use `composer update` from the command line and watch the magic. :-)
