### PR TITLE
Change type to "wordpress-muplugin"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name"       : "pressjitsu/wp-transients-cleaner",
-	"type"       : "wordpress-plugin",
+	"type"       : "wordpress-muplugin",
 	"require"    : {
 		"composer/installers": "~1.0"
 	}


### PR DESCRIPTION
If the initial intention is to use it in "/wp-content/mu-plugins/", it makes more sense to use "wordpress-muplugin" as package type.

Specially useful when using [Bedrock](https://github.com/roots/bedrock)
